### PR TITLE
Fix make not recompiling when code is updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: a.out
 
-a.out:
+a.out: main.cpp shapes.h
 	g++ -std=c++11 main.cpp
 
 test: a.out


### PR DESCRIPTION
Currently, the Makefile is set up to only compile when a.out does not exist. Ideally, we want make to recompile whenever the source code is updated. This pull request fixes this issue.